### PR TITLE
Removed "dateCreated" column requirement

### DIFF
--- a/crud.js
+++ b/crud.js
@@ -28,9 +28,6 @@ module.exports = function (db, table) {
   table = mysql.escapeId(table);
   return {
     'create' : function (attrs, next) {
-      if (attrs.dateCreated === undefined) {
-        attrs.dateCreated = new Date();
-      }
       db.getConnection(function (conErr, connection) {
         if (conErr) { return next(conErr); }
         connection.query("INSERT INTO " + table + " SET ?", attrs, function (err, rows) {


### PR DESCRIPTION
An error is thrown when trying to use this package with a table that doesn't have the "dateCreated" column.
